### PR TITLE
add forecast module

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -58,3 +58,16 @@ module "nwp" {
   ecs-cluster             = module.ecs.ecs_cluster
   subnet_ids              = [module.networking.public_subnets[0].id]
 }
+
+
+module "forecast" {
+  source = "../modules/services/forecast"
+
+  region                  = var.region
+  environment             = var.environment
+  ecs-cluster             = module.ecs.ecs_cluster
+  subnet_ids              = [module.networking.public_subnets[0].id]
+  iam-policy-read-secret = module.database.iam-policy-db-read
+  iam-policy-s3-nwp-read = module.s3.iam-policy-s3-nwp-read
+  database_secret         = module.database.database-secret
+}

--- a/terraform/modules/database/output.tf
+++ b/terraform/modules/database/output.tf
@@ -1,0 +1,9 @@
+output "iam-policy-db-read" {
+  value = aws_iam_policy.rds-secret-policy
+}
+
+output "database-secret" {
+  value = aws_secretsmanager_secret.DB-forecast-secret
+}
+
+

--- a/terraform/modules/database/output.tf
+++ b/terraform/modules/database/output.tf
@@ -5,5 +5,3 @@ output "iam-policy-db-read" {
 output "database-secret" {
   value = aws_secretsmanager_secret.DB-forecast-secret
 }
-
-

--- a/terraform/modules/database/rds.tf
+++ b/terraform/modules/database/rds.tf
@@ -16,6 +16,7 @@ resource "aws_db_instance" "DB-forecast" {
   backup_window              = "00:00-00:30"
   db_subnet_group_name       = var.db_subnet_group.name # update name with private/public
   auto_minor_version_upgrade = true
+  performance_insights_enabled = true
 
   tags = {
     Name        = "${var.environment}-rds"

--- a/terraform/modules/database/secrets.tf
+++ b/terraform/modules/database/secrets.tf
@@ -5,7 +5,7 @@
 resource "random_password" "DB-forecast-password" {
   length           = 16
   special          = true
-  override_special = "_%@"
+  override_special = "%"
 }
 
 
@@ -24,11 +24,11 @@ resource "aws_secretsmanager_secret_version" "sversion" {
   secret_string = jsonencode(
     {
       username : "main",
-      password : "${random_password.DB-forecast-password.result}",
+      password : random_password.DB-forecast-password.result,
       dbname : aws_db_instance.DB-forecast.name,
       engine : "postgresql",
       address : aws_db_instance.DB-forecast.address,
-      post : "5432",
-      url : "postgresql://main:${random_password.DB-forecast-password.result}@:${aws_db_instance.DB-forecast.address}/${aws_db_instance.DB-forecast.name}"
+      port : "5432",
+      url : "postgresql://main:${random_password.DB-forecast-password.result}@${aws_db_instance.DB-forecast.address}:5432/${aws_db_instance.DB-forecast.name}"
   })
 }

--- a/terraform/modules/s3/output.tf
+++ b/terraform/modules/s3/output.tf
@@ -2,6 +2,10 @@ output "iam-policy-s3-nwp-write" {
   value = aws_iam_policy.iam-policy-s3-nwp-write
 }
 
+output "iam-policy-s3-nwp-read" {
+  value = aws_iam_policy.iam-policy-s3-nwp-read
+}
+
 output "s3-nwp-bucket" {
   value = aws_s3_bucket.s3-nwp-bucket
 }

--- a/terraform/modules/services/forecast/README.md
+++ b/terraform/modules/services/forecast/README.md
@@ -1,0 +1,5 @@
+This module currently makes
+- AWS task definition
+- IAM role to setup application 
+- IAM role for running task 
+- temp: scheduled aws task, and iam roles

--- a/terraform/modules/services/forecast/README.md
+++ b/terraform/modules/services/forecast/README.md
@@ -1,5 +1,5 @@
 This module currently makes
 - AWS task definition
-- IAM role to setup application 
-- IAM role for running task 
+- IAM role to setup application
+- IAM role for running task
 - temp: scheduled aws task, and iam roles

--- a/terraform/modules/services/forecast/cloudwatch.tf
+++ b/terraform/modules/services/forecast/cloudwatch.tf
@@ -1,0 +1,12 @@
+# set up cloudwatch log group
+
+resource "aws_cloudwatch_log_group" "forecast" {
+  name = var.log-group-name
+
+  retention_in_days = 7
+
+  tags = {
+    Environment = var.environment
+    Application = "nowcasting"
+  }
+}

--- a/terraform/modules/services/forecast/ecs.tf
+++ b/terraform/modules/services/forecast/ecs.tf
@@ -1,0 +1,46 @@
+# define aws ecs task definition
+# needs access to the internet
+
+resource "aws_ecs_task_definition" "forecast-task-definition" {
+  family                   = "forecast"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+
+  # specific values are needed -
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
+  cpu    = 256
+  memory = 512
+
+  task_role_arn      = aws_iam_role.forecast-iam-role.arn
+  execution_role_arn = aws_iam_role.ecs_task_execution_role-forecast.arn
+  container_definitions = jsonencode([
+    {
+      name  = "forecast"
+      image = "openclimatefix/nowcasting_forecast:latest"
+      #      cpu       = 128
+      #      memory    = 128
+      essential = true
+
+      environment : [
+        { "name" : "FAKE", "value" : "True" },
+      ]
+
+      secrets : [
+        {
+          "name" : "DB_URL",
+          "valueFrom" : "${var.database_secret.arn}:url::",
+        }
+      ]
+
+      logConfiguration : {
+        "logDriver" : "awslogs",
+        "options" : {
+          "awslogs-group" : var.log-group-name,
+          "awslogs-region" : var.region,
+          "awslogs-stream-prefix" : "streaming"
+        }
+      }
+    }
+  ])
+
+}

--- a/terraform/modules/services/forecast/iam.tf
+++ b/terraform/modules/services/forecast/iam.tf
@@ -1,0 +1,98 @@
+# Define the IAM task execution role and the instance role
+# Execution role is used to deploy the task
+# Instance role is used to run the task
+
+resource "aws_iam_role" "ecs_task_execution_role-forecast" {
+  name = "ecs-forecast-execution-role"
+
+  assume_role_policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+       "Service": "ecs-tasks.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
+ ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "cloudwatch-forecast" {
+  name        = "cloudwatch-read-and-write-forecast"
+  path        = "/forecast/"
+  description = "Policy to allow read and write to cloudwatch logs"
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:PutLogEvents",
+          "logs:CreateLogStream",
+          "logs:CreateLogGroup",
+          "logs:DescribeLogStreams",
+          "logs:DescribeLogGroups",
+          "logs:DeleteLogGroup",
+          "logs:PutRetentionPolicy"
+        ]
+        Effect   = "Allow"
+        Resource = "arn:aws:logs:*:*:log-group:${var.log-group-name}*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-policy-attachment" {
+  role       = aws_iam_role.ecs_task_execution_role-forecast.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "attach-logs-execution" {
+  role       = aws_iam_role.ecs_task_execution_role-forecast.name
+  policy_arn = aws_iam_policy.cloudwatch-forecast.arn
+}
+
+
+data "aws_iam_policy_document" "ec2-instance-assume-role-policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "forecast-iam-role" {
+  name               = "forecast-iam-role"
+  path               = "/forecast/"
+  assume_role_policy = data.aws_iam_policy_document.ec2-instance-assume-role-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach-write-s3" {
+  role       = aws_iam_role.forecast-iam-role.name
+  policy_arn = var.iam-policy-s3-nwp-read.arn
+}
+
+resource "aws_iam_role_policy_attachment" "attach-logs" {
+  role       = aws_iam_role.forecast-iam-role.name
+  policy_arn = aws_iam_policy.cloudwatch-forecast.arn
+}
+
+resource "aws_iam_role_policy_attachment" "read-secret-execution" {
+  role       = aws_iam_role.ecs_task_execution_role-forecast.name
+  policy_arn = var.iam-policy-read-secret.arn
+}
+
+resource "aws_iam_role_policy_attachment" "read-secret" {
+  role       = aws_iam_role.forecast-iam-role.name
+  policy_arn = var.iam-policy-read-secret.arn
+}

--- a/terraform/modules/services/forecast/schedule-iam.tf
+++ b/terraform/modules/services/forecast/schedule-iam.tf
@@ -1,0 +1,54 @@
+# This is an temporary module.
+# This will schedule the aws task to run on cron job.
+# We want to move to Dagster but for the moment its useful to have this setup
+
+// Cloudwatch execution role
+data "aws_iam_policy_document" "cloudwatch_assume_role" {
+  statement {
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "ecs-tasks.amazonaws.com",
+      ]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch" {
+
+  statement {
+    effect    = "Allow"
+    actions   = ["ecs:RunTask"]
+    resources = [aws_ecs_task_definition.forecast-task-definition.arn]
+  }
+  statement {
+    effect  = "Allow"
+    actions = ["iam:PassRole"]
+    resources = concat([
+      aws_iam_role.ecs_task_execution_role-forecast.arn,
+    aws_iam_role.forecast-iam-role.arn])
+  }
+}
+
+resource "aws_iam_role" "cloudwatch_role" {
+  name               = "forecast-schedule-cloudwatch-execution"
+  assume_role_policy = data.aws_iam_policy_document.cloudwatch_assume_role.json
+
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch" {
+  role       = aws_iam_role.cloudwatch_role.name
+  policy_arn = aws_iam_policy.cloudwatch.arn
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch-secret" {
+  role       = aws_iam_role.cloudwatch_role.name
+  policy_arn = var.iam-policy-read-secret.arn
+}
+
+resource "aws_iam_policy" "cloudwatch" {
+  name   = "forecast-schedule-cloudwatch-execution"
+  policy = data.aws_iam_policy_document.cloudwatch.json
+}

--- a/terraform/modules/services/forecast/schedule.tf
+++ b/terraform/modules/services/forecast/schedule.tf
@@ -1,0 +1,32 @@
+# This is an temporary module.
+# This will schedule the aws task to run on cron job.
+# We want to move to Dagster but for the moment its useful to have this setup
+
+resource "aws_cloudwatch_event_rule" "event_rule-forecast" {
+  name                = "forecast-schedule-${var.environment}"
+  schedule_expression = "cron(0,5,10,15,20,25,30,35,40,45,50,55 * * * ? *)" # runs every 5 mins
+}
+
+resource "aws_cloudwatch_event_target" "ecs_scheduled_task-forecast" {
+
+  rule      = aws_cloudwatch_event_rule.event_rule-forecast.name
+  target_id = "forecast-schedule-${var.environment}"
+  arn       = var.ecs-cluster.arn
+  role_arn  = aws_iam_role.cloudwatch_role.arn
+
+  ecs_target {
+
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.forecast-task-definition.arn
+    network_configuration {
+
+      subnets          = var.subnet_ids
+      assign_public_ip = true
+
+    }
+
+  }
+
+}

--- a/terraform/modules/services/forecast/variables.tf
+++ b/terraform/modules/services/forecast/variables.tf
@@ -1,0 +1,37 @@
+
+variable "environment" {
+  description = "The Deployment environment"
+}
+
+
+variable "region" {
+  description = "The AWS region"
+}
+
+
+variable "iam-policy-s3-nwp-read" {
+  description = "IAM policy to read to s3 bucket for NWP data"
+}
+
+variable "log-group-name" {
+  description = "The log group name where log streams are saved"
+  default     = "/aws/ecs/forecast/"
+}
+
+
+variable "ecs-cluster" {
+  description = "The ECS cluster"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Public subnet ids"
+}
+
+variable "iam-policy-read-secret" {
+  description = "IAM policy to be able to read the RDS secret"
+}
+
+variable "database_secret" {
+  description = "AWS secret that gives connection details to the database"
+}

--- a/terraform/modules/services/nwp/README.md
+++ b/terraform/modules/services/nwp/README.md
@@ -1,0 +1,6 @@
+This module currently makes
+- AWS task definition
+- IAM role to setup application 
+- IAM role for running task 
+- get secrets for NWP API
+- temp: scheduled aws task, and iam roles

--- a/terraform/modules/services/nwp/README.md
+++ b/terraform/modules/services/nwp/README.md
@@ -1,6 +1,6 @@
 This module currently makes
 - AWS task definition
-- IAM role to setup application 
-- IAM role for running task 
+- IAM role to setup application
+- IAM role for running task
 - get secrets for NWP API
 - temp: scheduled aws task, and iam roles


### PR DESCRIPTION
# Pull Request

## Description

add forecast module
- ecs task definition
- iam role
- aws scheduled task

Fixes #

## How Has This Been Tested?

ran terraform apply and forecast task runs and saves predictions to the database

- [ ] No
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
