### PR TITLE
update pv to use forecast database

### DIFF
--- a/terraform/modules/services/pv/ecs.tf
+++ b/terraform/modules/services/pv/ecs.tf
@@ -38,6 +38,10 @@ resource "aws_ecs_task_definition" "pv-task-definition" {
         {
           "name" : "DB_URL",
           "valueFrom" : "${var.database_secret.arn}:url::",
+        },
+        {
+          "name" : "DB_URL_FORECAST",
+          "valueFrom" : "${var.database_secret_forecast.arn}:url::",
         }
       ]
 

--- a/terraform/modules/services/pv/iam.tf
+++ b/terraform/modules/services/pv/iam.tf
@@ -124,3 +124,13 @@ resource "aws_iam_role_policy_attachment" "read-db-secret" {
   role       = aws_iam_role.consumer-pv-iam-role.name
   policy_arn = var.iam-policy-rds-read-secret.arn
 }
+
+resource "aws_iam_role_policy_attachment" "read-db-secret-execution-forecast" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = var.iam-policy-rds-read-secret_forecast.arn
+}
+
+resource "aws_iam_role_policy_attachment" "read-db-secret-forecast" {
+  role       = aws_iam_role.consumer-pv-iam-role.name
+  policy_arn = var.iam-policy-rds-read-secret_forecast.arn
+}

--- a/terraform/modules/services/pv/variables.tf
+++ b/terraform/modules/services/pv/variables.tf
@@ -28,8 +28,16 @@ variable "database_secret" {
   description = "AWS secret that gives connection details to the database"
 }
 
+variable "database_secret_forecast" {
+  description = "AWS secret that gives connection details to the forecast database"
+}
+
 variable "iam-policy-rds-read-secret" {
   description = "IAM policy to be able to read the RDS secret"
+}
+
+variable "iam-policy-rds-read-secret_forecast" {
+  description = "IAM policy to be able to read the forecast RDS secret"
 }
 
 variable "docker_version" {


### PR DESCRIPTION
# Pull Request

## Description

Give PV consumer access to forecast database

## How Has This Been Tested?

terraform validation and plan

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
