### PR TITLE
allow forecasdt to read satellite s3

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -136,6 +136,7 @@ module "forecast" {
   iam-policy-rds-read-secret    = module.database.iam-policy-forecast-db-read
   iam-policy-rds-pv-read-secret = module.database.iam-policy-pv-db-read
   iam-policy-s3-nwp-read        = module.s3.iam-policy-s3-nwp-read
+  iam-policy-s3-sat-read        = module.s3.iam-policy-s3-sat-read
   iam-policy-s3-ml-read         = module.s3.iam-policy-s3-ml-read
   database_secret               = module.database.forecast-database-secret
   docker_version                = var.forecast_version

--- a/terraform/modules/services/forecast/iam.tf
+++ b/terraform/modules/services/forecast/iam.tf
@@ -82,6 +82,11 @@ resource "aws_iam_role_policy_attachment" "attach-write-s3" {
   policy_arn = var.iam-policy-s3-nwp-read.arn
 }
 
+resource "aws_iam_role_policy_attachment" "attach-write-s3-sat" {
+  role       = aws_iam_role.forecast-iam-role.name
+  policy_arn = var.iam-policy-s3-sat-read.arn
+}
+
 resource "aws_iam_role_policy_attachment" "attach-write-s3-ml" {
   role       = aws_iam_role.forecast-iam-role.name
   policy_arn = var.iam-policy-s3-ml-read.arn

--- a/terraform/modules/services/forecast/variables.tf
+++ b/terraform/modules/services/forecast/variables.tf
@@ -13,6 +13,10 @@ variable "iam-policy-s3-nwp-read" {
   description = "IAM policy to read to s3 bucket for NWP data"
 }
 
+variable "iam-policy-s3-sat-read" {
+  description = "IAM policy to read to s3 bucket for Satellite data"
+}
+
 variable "iam-policy-s3-ml-read" {
   description = "IAM policy to read to s3 bucket for ML models"
 }


### PR DESCRIPTION
# Pull Request

## Description

add read access to s3 for forecast

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
