### PR TITLE
add 20 and 50 calls on GSP data

### DIFF
--- a/terraform/modules/services/gsp/schedule.tf
+++ b/terraform/modules/services/gsp/schedule.tf
@@ -4,7 +4,7 @@
 
 resource "aws_cloudwatch_event_rule" "event_rule" {
   name                = "gsp-schedule-${var.environment}"
-  schedule_expression = "cron(9,12,14,39,42,44 * * * ? *)"
+  schedule_expression = "cron(9,12,14,20,39,42,44,50 * * * ? *)"
   # runs every 30 minutes at 9 and 39 past
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Run GSP consumer also at 20 and 50 minutes past the hour

Fixes #https://github.com/openclimatefix/nowcasting_infrastructure/issues/97

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
