### PR TITLE
Add more ram as kills process on 15-minutely data

### DIFF
--- a/terraform/modules/services/sat/ecs.tf
+++ b/terraform/modules/services/sat/ecs.tf
@@ -9,7 +9,7 @@ resource "aws_ecs_task_definition" "sat-task-definition" {
   # specific values are needed -
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
   cpu    = 512
-  memory = 2048
+  memory = 4096
 
   task_role_arn      = aws_iam_role.consumer-sat-iam-role.arn
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn


### PR DESCRIPTION
# Pull Request

## Description

When using 15-minutely data, the containrs run out of ram and are killed. I think doubling the ram should be enough for it to work.

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
