### PR TITLE
Update schedule.tf

### DIFF
--- a/terraform/modules/services/gsp/schedule.tf
+++ b/terraform/modules/services/gsp/schedule.tf
@@ -34,8 +34,9 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
 
 resource "aws_cloudwatch_event_rule" "event_rule_day_after" {
   name                = "gsp-day-after-schedule-${var.environment}"
-  schedule_expression = "cron(0 7 * * ? *)"
-  # runs every morning at 7 UTC
+  schedule_expression = "cron(45 10,11 * * ? *)"
+  # Data is run at 10.30 local time by sheffield solar. 
+  # Therefore we run this every morning at 10:45 UTC (and 11:45) for BST
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task_day_after" {


### PR DESCRIPTION
Run gsp consumer at 10.45 to get day after results

# Pull Request

## Description

Run gsp consumer at 10.45 to get day after results
THis is new information from Solar Sheffield

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
