### PR TITLE
reduce api cloudwatch time to 7 days

### DIFF
--- a/terraform/modules/services/api/eb.tf
+++ b/terraform/modules/services/api/eb.tf
@@ -114,7 +114,7 @@ resource "aws_elastic_beanstalk_environment" "eb-api-env" {
   setting {
     namespace = "aws:elasticbeanstalk:cloudwatch:logs"
     name      = "RetentionInDays"
-    value     = "30"
+    value     = "7"
     resource  = ""
   }
 
@@ -135,7 +135,7 @@ resource "aws_elastic_beanstalk_environment" "eb-api-env" {
   setting {
     namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
     name      = "RetentionInDays"
-    value     = "30"
+    value     = "7"
     resource  = ""
   }
 


### PR DESCRIPTION
# Pull Request

## Description

Reduce api cloudwatch to 7 days. 
We need to think of a different way to log the number of hits to the api

Fixes #

## How Has This Been Tested?

CI
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
